### PR TITLE
Refactor brief_store action-item normalization into testable helper

### DIFF
--- a/tests/tools/test_pm_brief_tools.py
+++ b/tests/tools/test_pm_brief_tools.py
@@ -1,0 +1,62 @@
+import json
+
+from tools import pm_brief_tools
+
+
+def test_normalize_action_items_parses_and_applies_defaults(monkeypatch):
+    monkeypatch.setattr(
+        pm_brief_tools,
+        "_extract_references",
+        lambda text: [{"type": "issue", "url": "https://example.com/1", "title": text.strip()}],
+    )
+
+    items, error = pm_brief_tools._normalize_action_items(
+        json.dumps(
+            [
+                {"title": "Investigate drop", "description": "Check conversion regression"},
+                {
+                    "category": "team",
+                    "title": "Sync with eng",
+                    "description": "Review blockers",
+                    "priority": "high",
+                    "references": [{"type": "pr", "url": "https://example.com/pr/1", "title": "PR 1"}],
+                },
+            ]
+        )
+    )
+
+    assert error is None
+    assert items == [
+        {
+            "category": "risk",
+            "title": "Investigate drop",
+            "description": "Check conversion regression",
+            "priority": "medium",
+            "references": [
+                {
+                    "type": "issue",
+                    "url": "https://example.com/1",
+                    "title": "Investigate drop Check conversion regression",
+                }
+            ],
+        },
+        {
+            "category": "team",
+            "title": "Sync with eng",
+            "description": "Review blockers",
+            "priority": "high",
+            "references": [{"type": "pr", "url": "https://example.com/pr/1", "title": "PR 1"}],
+        },
+    ]
+
+
+def test_normalize_action_items_rejects_invalid_json():
+    items, error = pm_brief_tools._normalize_action_items('{"not":"an array"}')
+    assert items is None
+    assert error == "action_items must be valid JSON array"
+
+
+def test_normalize_action_items_rejects_non_list_input():
+    items, error = pm_brief_tools._normalize_action_items({"title": "invalid"})
+    assert items is None
+    assert error == "action_items must be valid JSON array"

--- a/tools/pm_brief_tools.py
+++ b/tools/pm_brief_tools.py
@@ -179,6 +179,38 @@ def _get_db():
     return db
 
 
+def _normalize_action_items(action_items):
+    """Parse and normalize brief action items into a consistent list of dicts."""
+    try:
+        parsed_items = json.loads(action_items) if isinstance(action_items, str) else action_items
+    except json.JSONDecodeError:
+        return None, "action_items must be valid JSON array"
+
+    if not isinstance(parsed_items, list):
+        return None, "action_items must be valid JSON array"
+
+    normalized_items = []
+    for item in parsed_items:
+        item_data = item if isinstance(item, dict) else {}
+        title = item_data.get("title", "")
+        description = item_data.get("description", "")
+        refs = item_data.get("references", [])
+        if not isinstance(refs, list):
+            refs = []
+        if not refs:
+            refs = _extract_references(f"{title} {description}")
+
+        normalized_items.append({
+            "category": item_data.get("category", "risk"),
+            "title": title,
+            "description": description,
+            "priority": item_data.get("priority", "medium"),
+            "references": refs,
+        })
+
+    return normalized_items, None
+
+
 # =============================================================================
 # Tool: brief_store
 # =============================================================================
@@ -189,11 +221,9 @@ def brief_store(summary: str, action_items: str, headline: str = "", data_source
     brief_id = str(uuid.uuid4())[:8]
     now = time.time()
 
-    # Parse action items JSON
-    try:
-        items = json.loads(action_items) if isinstance(action_items, str) else action_items
-    except json.JSONDecodeError:
-        return json.dumps({"error": "action_items must be valid JSON array"})
+    items, error = _normalize_action_items(action_items)
+    if error:
+        return json.dumps({"error": error})
 
     # Parse suggested prompts
     try:
@@ -211,15 +241,11 @@ def brief_store(summary: str, action_items: str, headline: str = "", data_source
     # Store individual action items
     for item in items:
         action_id = str(uuid.uuid4())[:8]
-        # Extract references: explicit from agent, or auto-detect from text
-        refs = item.get("references", [])
-        if not refs:
-            refs = _extract_references(item.get("title", "") + " " + item.get("description", ""))
         db.execute(
             "INSERT INTO brief_actions (id, brief_id, category, title, description, priority, status, references_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)",
             (action_id, brief_id, item.get("category", "risk"), item.get("title", ""),
              item.get("description", ""), item.get("priority", "medium"),
-             json.dumps(refs), now, now)
+             json.dumps(item.get("references", [])), now, now)
         )
 
     db.commit()


### PR DESCRIPTION
### Motivation
- Extract the action-item parsing/normalization from `brief_store` so the logic can be unit-tested and reused.
- Centralize defaults and reference-extraction fallback to reduce duplication and improve reliability when persisting action items.

### Description
- Added helper `def _normalize_action_items(action_items)` in `tools/pm_brief_tools.py` which parses JSON or list input, validates that it is an array, applies defaults (`category='risk'`, `priority='medium'`), and auto-extracts references via `_extract_references` when `references` is empty.
- Updated `brief_store` to call `_normalize_action_items` and persist the normalized action items (storing their `references`), preserving the tool's external behaviour and DB schema usage.
- Added unit tests `tests/tools/test_pm_brief_tools.py` that cover default normalization, reference fallback via a monkeypatched `_extract_references`, and invalid/non-list input handling, while keeping existing `brief_store` tests unchanged.
- PR body includes `Closes #18` to link this change to the issue.

### Testing
- Ran `pytest -q -o addopts='' tests/tools/test_pm_brief_tools.py` and the new tests passed (`3 passed`).
- Existing `brief_store` behaviour and tests were not modified by this change and the helper was exercised by the new unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3ebd9bdc8321816104265fc2e5d2)