### PR TITLE
Add Supabase tenant auth middleware and propagate tenant context to PM tools

### DIFF
--- a/backend/tenant_auth.py
+++ b/backend/tenant_auth.py
@@ -1,0 +1,102 @@
+"""Supabase JWT + membership resolution for tenant-scoped API requests."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import jwt
+from fastapi import HTTPException, Request, status
+
+from backend.db.supabase_client import get_service_role_client, get_supabase_settings
+from backend.tenant_context import TenantContext
+
+
+TENANT_SCOPED_PATH_PREFIXES = (
+    "/api/tenant",
+    "/api/brief",
+    "/api/briefs",
+    "/api/goals",
+    "/api/kpis",
+    "/api/workspace",
+    "/api/chat",
+)
+
+
+def is_tenant_scoped_path(path: str) -> bool:
+    return any(path.startswith(prefix) for prefix in TENANT_SCOPED_PATH_PREFIXES)
+
+
+def _extract_bearer_token(request: Request) -> str:
+    auth_header = request.headers.get("authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Supabase JWT")
+    token = auth_header.replace("Bearer ", "", 1).strip()
+    if not token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Supabase JWT")
+    return token
+
+
+def decode_supabase_jwt(token: str) -> dict:
+    settings = get_supabase_settings()
+    try:
+        payload = jwt.decode(token, settings.jwt_secret, algorithms=["HS256"], options={"verify_aud": False})
+    except jwt.InvalidTokenError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=f"Invalid Supabase JWT: {exc}") from exc
+    sub = str(payload.get("sub") or "").strip()
+    if not sub:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Supabase JWT is missing 'sub'")
+    return payload
+
+
+def resolve_tenant_membership(user_id: str, requested_tenant_id: Optional[str] = None) -> TenantContext:
+    client = get_service_role_client()
+    response = (
+        client.table("tenant_memberships")
+        .select("tenant_id,role,is_default")
+        .eq("user_id", user_id)
+        .execute()
+    )
+    memberships = response.data or []
+    if not memberships:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Authenticated user has no tenant membership",
+        )
+
+    membership = None
+    if requested_tenant_id:
+        membership = next((m for m in memberships if m.get("tenant_id") == requested_tenant_id), None)
+        if not membership:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"User is not a member of tenant '{requested_tenant_id}'",
+            )
+    else:
+        membership = next((m for m in memberships if m.get("is_default") is True), None) or memberships[0]
+
+    return TenantContext(
+        user_id=user_id,
+        tenant_id=str(membership.get("tenant_id") or "").strip(),
+        role=str(membership.get("role") or "member").strip() or "member",
+    )
+
+
+def build_tenant_context(request: Request) -> TenantContext:
+    token = _extract_bearer_token(request)
+    payload = decode_supabase_jwt(token)
+    user_id = str(payload.get("sub"))
+    requested_tenant_id = request.headers.get("x-tenant-id", "").strip() or None
+    return resolve_tenant_membership(user_id, requested_tenant_id)
+
+
+def get_current_tenant(request: Request) -> TenantContext:
+    context = getattr(request.state, "tenant_context", None)
+    if context is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=(
+                "Tenant context was not resolved for this tenant-scoped endpoint. "
+                "This indicates middleware misconfiguration."
+            ),
+        )
+    return context

--- a/backend/tenant_context.py
+++ b/backend/tenant_context.py
@@ -1,0 +1,87 @@
+"""Tenant context utilities shared across API, tools, and gateway flows."""
+
+from __future__ import annotations
+
+import os
+from contextvars import ContextVar, Token
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class TenantContext:
+    user_id: str
+    tenant_id: str
+    role: str
+
+
+_current_tenant: ContextVar[Optional[TenantContext]] = ContextVar("current_tenant", default=None)
+
+
+class TenantContextError(RuntimeError):
+    """Raised when tenant context is required but unavailable."""
+
+
+def set_current_tenant(context: TenantContext) -> Token:
+    return _current_tenant.set(context)
+
+
+def reset_current_tenant(token: Token) -> None:
+    _current_tenant.reset(token)
+
+
+def get_current_tenant() -> Optional[TenantContext]:
+    return _current_tenant.get()
+
+
+def _from_mapping(data: Mapping[str, Any]) -> Optional[TenantContext]:
+    tenant_id = str(data.get("tenant_id") or "").strip()
+    if not tenant_id:
+        return None
+    return TenantContext(
+        user_id=str(data.get("user_id") or "unknown").strip() or "unknown",
+        tenant_id=tenant_id,
+        role=str(data.get("role") or "member").strip() or "member",
+    )
+
+
+def resolve_tenant_context(kwargs: Optional[Mapping[str, Any]] = None) -> Optional[TenantContext]:
+    if kwargs:
+        embedded = kwargs.get("tenant_context")
+        if isinstance(embedded, TenantContext):
+            return embedded
+        if isinstance(embedded, Mapping):
+            mapped = _from_mapping(embedded)
+            if mapped:
+                return mapped
+
+        mapped = _from_mapping(kwargs)
+        if mapped:
+            return mapped
+
+    from_ctx = get_current_tenant()
+    if from_ctx:
+        return from_ctx
+
+    tenant_id = (
+        os.getenv("KAI_TENANT_ID", "").strip()
+        or os.getenv("HERMES_TENANT_ID", "").strip()
+    )
+    if not tenant_id:
+        return None
+
+    return TenantContext(
+        user_id=(os.getenv("KAI_USER_ID", "").strip() or "gateway-user"),
+        tenant_id=tenant_id,
+        role=(os.getenv("KAI_TENANT_ROLE", "").strip() or "member"),
+    )
+
+
+def require_tenant_context(*, kwargs: Optional[Mapping[str, Any]] = None, consumer: str) -> TenantContext:
+    context = resolve_tenant_context(kwargs)
+    if context:
+        return context
+    raise TenantContextError(
+        f"Tenant context is required for {consumer}. "
+        "No tenant_id was resolved from request context, tool arguments, or session environment."
+    )

--- a/docs/supabase-setup.md
+++ b/docs/supabase-setup.md
@@ -114,3 +114,28 @@ Optional test-only vars:
 
 - `GET /api/health/supabase` should return `{ "ok": true, "latency_ms": <number> }`.
 - Run `pytest tests/integration/test_supabase_rls_integration.py -m integration`.
+
+## 7) Tenant auth + middleware behavior (#27)
+
+Tenant-scoped API paths (`/api/brief*`, `/api/goals*`, `/api/kpis*`, `/api/workspace*`, `/api/chat`) now require a Supabase JWT:
+
+- Missing/empty `Authorization: Bearer <jwt>` → `401` (`"Missing Supabase JWT"`).
+- Valid JWT with no matching row in `tenant_memberships` → `403`.
+- When tenant context is unexpectedly absent at a tenant-scoped endpoint dependency, API returns `500` with an explicit middleware-misconfiguration message (fail-closed).
+
+`x-tenant-id` is optional. If present, membership must match that tenant; otherwise default membership (or first membership) is used.
+
+## 8) Gateway tenant mapping hook (Slack/Telegram/etc.)
+
+Gateway dispatch can now map source identifiers to tenant IDs through `TENANT_SOURCE_MAP`.
+
+Example:
+
+```bash
+export TENANT_SOURCE_MAP='{
+  "slack:C01234567": "tenant-uuid-a",
+  "telegram:-100987654321": "tenant-uuid-b"
+}'
+```
+
+This sets `KAI_TENANT_ID`/`HERMES_TENANT_ID` in the gateway session env before tool dispatch. Full persistence/discovery wiring remains future work (this PR adds the interface + env-backed resolver stub).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -169,6 +169,7 @@ from gateway.session import (
 )
 from gateway.delivery import DeliveryRouter, DeliveryTarget
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.tenant_resolver import EnvTenantResolver
 
 logger = logging.getLogger(__name__)
 
@@ -274,6 +275,7 @@ class GatewayRunner:
         # Event hook system
         from gateway.hooks import HookRegistry
         self.hooks = HookRegistry()
+        self._tenant_resolver = EnvTenantResolver()
     
     def _flush_memories_for_session(self, old_session_id: str):
         """Prompt the agent to save memories/skills before context is lost.
@@ -2760,11 +2762,16 @@ class GatewayRunner:
         if context.source.chat_name:
             os.environ["KAI_SESSION_CHAT_NAME"] = context.source.chat_name
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
+        tenant_id = self._tenant_resolver.resolve(context.source)
+        if tenant_id:
+            os.environ["KAI_TENANT_ID"] = tenant_id
+            os.environ["HERMES_TENANT_ID"] = tenant_id
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
         for var in ["KAI_SESSION_PLATFORM", "KAI_SESSION_CHAT_ID", "KAI_SESSION_CHAT_NAME",
-                    "HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME"]:
+                    "HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME",
+                    "KAI_TENANT_ID", "HERMES_TENANT_ID"]:
             if var in os.environ:
                 del os.environ[var]
     

--- a/gateway/tenant_resolver.py
+++ b/gateway/tenant_resolver.py
@@ -1,0 +1,57 @@
+"""Gateway tenant mapping utilities.
+
+Maps platform/source identifiers (Slack channel IDs, Telegram chat IDs, etc.)
+to tenant IDs so gateway-triggered tool runs execute in the right tenant scope.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from gateway.session import SessionSource
+
+
+@dataclass
+class TenantResolver:
+    """Tenant resolver interface used by gateway dispatch paths."""
+
+    def resolve(self, source: SessionSource) -> Optional[str]:
+        raise NotImplementedError
+
+
+class EnvTenantResolver(TenantResolver):
+    """Resolve tenant IDs from TENANT_SOURCE_MAP JSON env configuration.
+
+    Example:
+      TENANT_SOURCE_MAP='{"slack:C123":"tenant-a","telegram:-10012345":"tenant-b"}'
+    """
+
+    def __init__(self, mapping: Optional[Dict[str, str]] = None):
+        self.mapping = mapping if mapping is not None else self._load_mapping()
+
+    @staticmethod
+    def _load_mapping() -> Dict[str, str]:
+        raw = os.getenv("TENANT_SOURCE_MAP", "").strip()
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                return {str(k): str(v) for k, v in parsed.items() if str(v).strip()}
+        except Exception:
+            pass
+        return {}
+
+    def resolve(self, source: SessionSource) -> Optional[str]:
+        platform = source.platform.value if source.platform else ""
+        candidates = [
+            f"{platform}:{source.chat_id}",
+            f"{platform}:{source.chat_name}" if source.chat_name else "",
+        ]
+        for key in candidates:
+            if key and key in self.mapping:
+                return self.mapping[key]
+        return None

--- a/server.py
+++ b/server.py
@@ -21,13 +21,16 @@ _project_env = Path(__file__).parent / ".env"
 if _project_env.exists():
     load_dotenv(dotenv_path=_project_env)
 
-from fastapi import FastAPI, Request
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import StreamingResponse, JSONResponse, RedirectResponse, HTMLResponse
 from starlette.middleware.cors import CORSMiddleware
 
 import sqlite3
 from kai_env import kai_home
 from workspace_context import load_workspace_context
+from backend.db.supabase_client import get_service_role_client, get_supabase_settings
+from backend.tenant_auth import build_tenant_context, get_current_tenant, is_tenant_scoped_path
+from backend.tenant_context import reset_current_tenant, set_current_tenant
 from tools.pm_brief_tools import _get_db
 
 # ── Integrations DB ────────────────────────────────────────────────────
@@ -81,6 +84,35 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Dash PM API")
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+
+@app.middleware("http")
+async def tenant_context_middleware(request: Request, call_next):
+    """Resolve per-request tenant context for tenant-scoped API paths."""
+    if not is_tenant_scoped_path(request.url.path):
+        return await call_next(request)
+
+    try:
+        tenant_context = build_tenant_context(request)
+    except Exception as exc:
+        from fastapi import HTTPException
+
+        if isinstance(exc, HTTPException):
+            return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+        raise
+    request.state.tenant_context = tenant_context
+
+    # Expose request tenant context to tool paths that execute within this request.
+    os.environ["KAI_TENANT_ID"] = tenant_context.tenant_id
+    os.environ["HERMES_TENANT_ID"] = tenant_context.tenant_id
+    os.environ["KAI_USER_ID"] = tenant_context.user_id
+    os.environ["KAI_TENANT_ROLE"] = tenant_context.role
+
+    token = set_current_tenant(tenant_context)
+    try:
+        return await call_next(request)
+    finally:
+        reset_current_tenant(token)
 
 
 # ── Auth ───────────────────────────────────────────────────────────────
@@ -2217,9 +2249,9 @@ def delete_session(session_id: str):
 # ── Workspace endpoint ─────────────────────────────────────────────────
 
 @app.get("/api/workspace/status")
-def workspace_status():
+def workspace_status(tenant=Depends(get_current_tenant)):
     try:
-        ctx = load_workspace_context(workspace_id=_ws_id())
+        ctx = load_workspace_context(workspace_id=tenant.tenant_id)
         bp = ctx.get_blueprint()
         learnings = ctx.get_learnings(limit=10)
         onboarding = ctx.get_onboarding_status()
@@ -2235,6 +2267,11 @@ def workspace_status():
         }
     except Exception as e:
         return {"error": str(e)}
+
+
+@app.get("/api/tenant/context")
+def tenant_context_debug(tenant=Depends(get_current_tenant)):
+    return {"user_id": tenant.user_id, "tenant_id": tenant.tenant_id, "role": tenant.role}
 
 
 @app.post("/api/chat")
@@ -2470,8 +2507,6 @@ def supabase_health():
     """Diagnostic: check Supabase REST reachability and basic query latency."""
     started_at = time.perf_counter()
     try:
-        from backend.db.supabase_client import get_service_role_client, get_supabase_settings
-
         settings = get_supabase_settings()
         get_service_role_client()  # validates env + client init
 

--- a/tests/test_tenant_auth_middleware.py
+++ b/tests/test_tenant_auth_middleware.py
@@ -1,0 +1,106 @@
+import os
+import sys
+import types
+
+import jwt
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+if "supabase" not in sys.modules:
+    fake_supabase = types.ModuleType("supabase")
+    fake_supabase.Client = object
+    fake_supabase.create_client = lambda *args, **kwargs: object()
+    sys.modules["supabase"] = fake_supabase
+
+if "supabase.lib.client_options" not in sys.modules:
+    sys.modules.setdefault("supabase.lib", types.ModuleType("supabase.lib"))
+    fake_client_options = types.ModuleType("supabase.lib.client_options")
+
+    class _ClientOptions:
+        def __init__(self, headers=None):
+            self.headers = headers or {}
+
+    fake_client_options.ClientOptions = _ClientOptions
+    sys.modules["supabase.lib.client_options"] = fake_client_options
+
+import server
+
+
+def _token(user_id: str) -> str:
+    secret = os.environ["SUPABASE_JWT_SECRET"]
+    return jwt.encode({"sub": user_id}, secret, algorithm="HS256")
+
+
+def test_tenant_middleware_missing_jwt_returns_401(monkeypatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service")
+
+    client = TestClient(server.app)
+    response = client.get("/api/tenant/context")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Missing Supabase JWT"
+
+
+def test_tenant_middleware_valid_jwt_without_membership_returns_403(monkeypatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service")
+
+    def _no_membership(user_id: str, requested_tenant_id=None):
+        raise HTTPException(status_code=403, detail="Authenticated user has no tenant membership")
+
+    monkeypatch.setattr("backend.tenant_auth.resolve_tenant_membership", _no_membership)
+
+    client = TestClient(server.app)
+    response = client.get(
+        "/api/tenant/context",
+        headers={"Authorization": f"Bearer {_token('user-no-membership')}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Authenticated user has no tenant membership"
+
+
+def test_tenant_middleware_resolves_membership_and_isolates_by_user(monkeypatch):
+    monkeypatch.setenv("SUPABASE_JWT_SECRET", "test-secret")
+    monkeypatch.setenv("SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "anon")
+    monkeypatch.setenv("SUPABASE_SERVICE_ROLE_KEY", "service")
+
+    tenant_map = {
+        "user-a": ("tenant-a", "owner"),
+        "user-b": ("tenant-b", "member"),
+    }
+
+    def _membership(user_id: str, requested_tenant_id=None):
+        if user_id not in tenant_map:
+            raise HTTPException(status_code=403, detail="Authenticated user has no tenant membership")
+        tenant_id, role = tenant_map[user_id]
+        from backend.tenant_context import TenantContext
+
+        if requested_tenant_id and requested_tenant_id != tenant_id:
+            raise HTTPException(status_code=403, detail=f"User is not a member of tenant '{requested_tenant_id}'")
+        return TenantContext(user_id=user_id, tenant_id=tenant_id, role=role)
+
+    monkeypatch.setattr("backend.tenant_auth.resolve_tenant_membership", _membership)
+
+    client = TestClient(server.app)
+
+    response_a = client.get(
+        "/api/tenant/context",
+        headers={"Authorization": f"Bearer {_token('user-a')}"},
+    )
+    response_b = client.get(
+        "/api/tenant/context",
+        headers={"Authorization": f"Bearer {_token('user-b')}"},
+    )
+
+    assert response_a.status_code == 200
+    assert response_a.json() == {"user_id": "user-a", "tenant_id": "tenant-a", "role": "owner"}
+
+    assert response_b.status_code == 200
+    assert response_b.json() == {"user_id": "user-b", "tenant_id": "tenant-b", "role": "member"}

--- a/tools/pm_brief_tools.py
+++ b/tools/pm_brief_tools.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Optional
 
 from kai_env import kai_home
+from backend.tenant_context import require_tenant_context
 
 _kai_home = kai_home()
 _DB_PATH = _kai_home / "workspace.db"
@@ -126,6 +127,7 @@ def _get_db():
     db.executescript("""
         CREATE TABLE IF NOT EXISTS briefs (
             id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             workspace_id TEXT NOT NULL DEFAULT 'default',
             summary TEXT NOT NULL,
             action_items TEXT NOT NULL,
@@ -134,6 +136,7 @@ def _get_db():
         );
         CREATE TABLE IF NOT EXISTS brief_actions (
             id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             brief_id TEXT NOT NULL,
             category TEXT NOT NULL,
             title TEXT NOT NULL,
@@ -148,7 +151,17 @@ def _get_db():
         CREATE INDEX IF NOT EXISTS idx_briefs_created ON briefs(created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_actions_brief ON brief_actions(brief_id);
         CREATE INDEX IF NOT EXISTS idx_actions_status ON brief_actions(status);
+        CREATE INDEX IF NOT EXISTS idx_briefs_tenant ON briefs(tenant_id, created_at DESC);
     """)
+    for table in ("briefs", "brief_actions"):
+        try:
+            db.execute(f"SELECT tenant_id FROM {table} LIMIT 0")
+        except Exception:
+            try:
+                db.execute(f"ALTER TABLE {table} ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
+                db.commit()
+            except Exception:
+                pass
     # Migration: add suggested_prompts column if missing
     try:
         db.execute("SELECT suggested_prompts FROM briefs LIMIT 0")
@@ -217,6 +230,7 @@ def _normalize_action_items(action_items):
 
 def brief_store(summary: str, action_items: str, headline: str = "", data_sources: str = "", suggested_prompts: str = "", **kwargs) -> str:
     """Store a completed brief with its action items."""
+    tenant = require_tenant_context(kwargs=kwargs, consumer="brief_store")
     db = _get_db()
     brief_id = str(uuid.uuid4())[:8]
     now = time.time()
@@ -233,17 +247,17 @@ def brief_store(summary: str, action_items: str, headline: str = "", data_source
 
     # Store brief
     db.execute(
-        "INSERT INTO briefs (id, summary, action_items, data_sources, suggested_prompts, headline, created_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        (brief_id, summary, json.dumps(items), data_sources, json.dumps(prompts), headline or "", now)
+        "INSERT INTO briefs (id, tenant_id, workspace_id, summary, action_items, data_sources, suggested_prompts, headline, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (brief_id, tenant.tenant_id, tenant.tenant_id, summary, json.dumps(items), data_sources, json.dumps(prompts), headline or "", now)
     )
 
     # Store individual action items
     for item in items:
         action_id = str(uuid.uuid4())[:8]
         db.execute(
-            "INSERT INTO brief_actions (id, brief_id, category, title, description, priority, status, references_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)",
-            (action_id, brief_id, item.get("category", "risk"), item.get("title", ""),
+            "INSERT INTO brief_actions (id, tenant_id, brief_id, category, title, description, priority, status, references_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)",
+            (action_id, tenant.tenant_id, brief_id, item.get("category", "risk"), item.get("title", ""),
              item.get("description", ""), item.get("priority", "medium"),
              json.dumps(item.get("references", [])), now, now)
         )
@@ -295,14 +309,15 @@ BRIEF_STORE_SCHEMA = {
 
 def brief_get_latest(**kwargs) -> str:
     """Get the most recent brief."""
+    tenant = require_tenant_context(kwargs=kwargs, consumer="brief_get_latest")
     db = _get_db()
-    row = db.execute("SELECT * FROM briefs ORDER BY created_at DESC LIMIT 1").fetchone()
+    row = db.execute("SELECT * FROM briefs WHERE tenant_id = ? ORDER BY created_at DESC LIMIT 1", (tenant.tenant_id,)).fetchone()
     if not row:
         return json.dumps({"message": "No briefs stored yet."})
 
     actions = db.execute(
-        "SELECT * FROM brief_actions WHERE brief_id = ? ORDER BY created_at",
-        (row["id"],)
+        "SELECT * FROM brief_actions WHERE tenant_id = ? AND brief_id = ? ORDER BY created_at",
+        (tenant.tenant_id, row["id"])
     ).fetchall()
 
     out = {
@@ -332,13 +347,14 @@ BRIEF_GET_LATEST_SCHEMA = {
 
 def brief_get_action_items(status: str = "pending", **kwargs) -> str:
     """Get action items filtered by status."""
+    tenant = require_tenant_context(kwargs=kwargs, consumer="brief_get_action_items")
     db = _get_db()
     if status == "all":
-        rows = db.execute("SELECT * FROM brief_actions ORDER BY created_at DESC LIMIT 20").fetchall()
+        rows = db.execute("SELECT * FROM brief_actions WHERE tenant_id = ? ORDER BY created_at DESC LIMIT 20", (tenant.tenant_id,)).fetchall()
     else:
         rows = db.execute(
-            "SELECT * FROM brief_actions WHERE status = ? ORDER BY created_at DESC LIMIT 20",
-            (status,)
+            "SELECT * FROM brief_actions WHERE tenant_id = ? AND status = ? ORDER BY created_at DESC LIMIT 20",
+            (tenant.tenant_id, status)
         ).fetchall()
 
     if not rows:
@@ -372,14 +388,15 @@ BRIEF_GET_ACTION_ITEMS_SCHEMA = {
 
 def brief_resolve_action(action_id: str, status: str = "resolved", **kwargs) -> str:
     """Update an action item's status."""
+    tenant = require_tenant_context(kwargs=kwargs, consumer="brief_resolve_action")
     db = _get_db()
-    row = db.execute("SELECT * FROM brief_actions WHERE id = ?", (action_id,)).fetchone()
+    row = db.execute("SELECT * FROM brief_actions WHERE id = ? AND tenant_id = ?", (action_id, tenant.tenant_id)).fetchone()
     if not row:
         return json.dumps({"error": f"Action item {action_id} not found."})
 
     db.execute(
-        "UPDATE brief_actions SET status = ?, updated_at = ? WHERE id = ?",
-        (status, time.time(), action_id)
+        "UPDATE brief_actions SET status = ?, updated_at = ? WHERE id = ? AND tenant_id = ?",
+        (status, time.time(), action_id, tenant.tenant_id)
     )
     db.commit()
     return json.dumps({"success": True, "action_id": action_id, "new_status": status})
@@ -421,14 +438,15 @@ registry.register(
         action_items=args.get("action_items", "[]"),
         headline=args.get("headline", ""),
         data_sources=args.get("data_sources", ""),
-        suggested_prompts=args.get("suggested_prompts", "[]")),
+        suggested_prompts=args.get("suggested_prompts", "[]"),
+        **kw),
 )
 
 registry.register(
     name="brief_get_latest",
     toolset="pm-brief",
     schema=BRIEF_GET_LATEST_SCHEMA,
-    handler=lambda args, **kw: brief_get_latest(),
+    handler=lambda args, **kw: brief_get_latest(**kw),
 )
 
 registry.register(
@@ -436,7 +454,8 @@ registry.register(
     toolset="pm-brief",
     schema=BRIEF_GET_ACTION_ITEMS_SCHEMA,
     handler=lambda args, **kw: brief_get_action_items(
-        status=args.get("status", "pending")),
+        status=args.get("status", "pending"),
+        **kw),
 )
 
 registry.register(
@@ -445,5 +464,6 @@ registry.register(
     schema=BRIEF_RESOLVE_ACTION_SCHEMA,
     handler=lambda args, **kw: brief_resolve_action(
         action_id=args.get("action_id", ""),
-        status=args.get("status", "resolved")),
+        status=args.get("status", "resolved"),
+        **kw),
 )

--- a/tools/pm_goal_tools.py
+++ b/tools/pm_goal_tools.py
@@ -16,6 +16,7 @@ import uuid
 from pathlib import Path
 
 from kai_env import kai_home
+from backend.tenant_context import require_tenant_context
 from tools.registry import registry
 
 
@@ -31,6 +32,7 @@ def _db() -> sqlite3.Connection:
     db.executescript("""
         CREATE TABLE IF NOT EXISTS goals (
             id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             title TEXT NOT NULL,
             description TEXT,
             target_date TEXT,
@@ -45,6 +47,7 @@ def _db() -> sqlite3.Connection:
         );
         CREATE TABLE IF NOT EXISTS goal_snapshots (
             id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             goal_id TEXT NOT NULL,
             progress INTEGER DEFAULT 0,
             trajectory TEXT,
@@ -54,8 +57,10 @@ def _db() -> sqlite3.Connection:
             created_at REAL NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_goal_snapshots_goal ON goal_snapshots(goal_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_goals_tenant ON goals(tenant_id, created_at DESC);
     """)
     for col, ddl in (
+        ("tenant_id", "ALTER TABLE goals ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'"),
         ("action_items", "ALTER TABLE goals ADD COLUMN action_items TEXT DEFAULT '[]'"),
         ("last_evaluated_at", "ALTER TABLE goals ADD COLUMN last_evaluated_at REAL"),
     ):
@@ -67,6 +72,14 @@ def _db() -> sqlite3.Connection:
                 db.commit()
             except Exception:
                 pass
+    try:
+        db.execute("SELECT tenant_id FROM goal_snapshots LIMIT 0")
+    except Exception:
+        try:
+            db.execute("ALTER TABLE goal_snapshots ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
+            db.commit()
+        except Exception:
+            pass
     return db
 
 
@@ -75,12 +88,13 @@ def _db() -> sqlite3.Connection:
 # =============================================================================
 
 def goal_list(status: str = "active", **kwargs) -> str:
+    tenant = require_tenant_context(kwargs=kwargs, consumer="goal_list")
     db = _db()
     if status == "all":
-        rows = db.execute("SELECT * FROM goals ORDER BY created_at DESC").fetchall()
+        rows = db.execute("SELECT * FROM goals WHERE tenant_id = ? ORDER BY created_at DESC", (tenant.tenant_id,)).fetchall()
     else:
         rows = db.execute(
-            "SELECT * FROM goals WHERE status = ? ORDER BY created_at DESC", (status,)
+            "SELECT * FROM goals WHERE tenant_id = ? AND status = ? ORDER BY created_at DESC", (tenant.tenant_id, status)
         ).fetchall()
     goals = []
     for r in rows:
@@ -115,8 +129,9 @@ GOAL_LIST_SCHEMA = {
 # =============================================================================
 
 def goal_get(goal_id: str, include_history: bool = False, **kwargs) -> str:
+    tenant = require_tenant_context(kwargs=kwargs, consumer="goal_get")
     db = _db()
-    row = db.execute("SELECT * FROM goals WHERE id = ?", (goal_id,)).fetchone()
+    row = db.execute("SELECT * FROM goals WHERE id = ? AND tenant_id = ?", (goal_id, tenant.tenant_id)).fetchone()
     if not row:
         return json.dumps({"error": f"Goal {goal_id} not found."})
     g = dict(row)
@@ -127,8 +142,8 @@ def goal_get(goal_id: str, include_history: bool = False, **kwargs) -> str:
             g[field] = []
     if include_history:
         hist_rows = db.execute(
-            "SELECT * FROM goal_snapshots WHERE goal_id = ? ORDER BY created_at DESC LIMIT 10",
-            (goal_id,),
+            "SELECT * FROM goal_snapshots WHERE goal_id = ? AND tenant_id = ? ORDER BY created_at DESC LIMIT 10",
+            (goal_id, tenant.tenant_id),
         ).fetchall()
         history = []
         for h in hist_rows:
@@ -173,8 +188,9 @@ def goal_update_progress(
     **kwargs,
 ) -> str:
     """Update a goal's progress and write a snapshot for trajectory tracking."""
+    tenant = require_tenant_context(kwargs=kwargs, consumer="goal_update_progress")
     db = _db()
-    row = db.execute("SELECT * FROM goals WHERE id = ?", (goal_id,)).fetchone()
+    row = db.execute("SELECT * FROM goals WHERE id = ? AND tenant_id = ?", (goal_id, tenant.tenant_id)).fetchone()
     if not row:
         return json.dumps({"error": f"Goal {goal_id} not found."})
 
@@ -189,14 +205,14 @@ def goal_update_progress(
     now = time.time()
 
     db.execute(
-        "UPDATE goals SET progress = ?, trajectory = ?, action_items = ?, last_evaluated_at = ?, updated_at = ? WHERE id = ?",
-        (progress, trajectory, json.dumps(items), now, now, goal_id),
+        "UPDATE goals SET progress = ?, trajectory = ?, action_items = ?, last_evaluated_at = ?, updated_at = ? WHERE id = ? AND tenant_id = ?",
+        (progress, trajectory, json.dumps(items), now, now, goal_id, tenant.tenant_id),
     )
     snapshot_id = uuid.uuid4().hex[:12]
     db.execute(
-        "INSERT INTO goal_snapshots (id, goal_id, progress, trajectory, action_items, brief_id, notes, created_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-        (snapshot_id, goal_id, progress, trajectory, json.dumps(items), brief_id or None, notes or None, now),
+        "INSERT INTO goal_snapshots (id, tenant_id, goal_id, progress, trajectory, action_items, brief_id, notes, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (snapshot_id, tenant.tenant_id, goal_id, progress, trajectory, json.dumps(items), brief_id or None, notes or None, now),
     )
     db.commit()
     return json.dumps({
@@ -258,7 +274,7 @@ registry.register(
     name="goal_list",
     toolset="pm-goals",
     schema=GOAL_LIST_SCHEMA,
-    handler=lambda args, **kw: goal_list(status=args.get("status", "active")),
+    handler=lambda args, **kw: goal_list(status=args.get("status", "active"), **kw),
 )
 
 registry.register(
@@ -268,6 +284,7 @@ registry.register(
     handler=lambda args, **kw: goal_get(
         goal_id=args.get("goal_id", ""),
         include_history=bool(args.get("include_history", False)),
+        **kw,
     ),
 )
 
@@ -282,5 +299,6 @@ registry.register(
         action_items=args.get("action_items", "[]"),
         brief_id=args.get("brief_id", ""),
         notes=args.get("notes", ""),
+        **kw,
     ),
 )

--- a/tools/pm_kpi_tools.py
+++ b/tools/pm_kpi_tools.py
@@ -14,6 +14,7 @@ import time
 import uuid
 
 from kai_env import kai_home
+from backend.tenant_context import require_tenant_context
 from tools.registry import registry
 
 
@@ -27,6 +28,7 @@ def _db() -> sqlite3.Connection:
     db.executescript("""
         CREATE TABLE IF NOT EXISTS kpis (
             id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             name TEXT NOT NULL,
             description TEXT,
             unit TEXT,
@@ -45,6 +47,7 @@ def _db() -> sqlite3.Connection:
         );
         CREATE TABLE IF NOT EXISTS kpi_values (
             id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             kpi_id TEXT NOT NULL,
             value REAL NOT NULL,
             source TEXT,
@@ -54,6 +57,7 @@ def _db() -> sqlite3.Connection:
         CREATE INDEX IF NOT EXISTS idx_kpi_values_kpi ON kpi_values(kpi_id, recorded_at DESC);
         CREATE TABLE IF NOT EXISTS kpi_flags (
             id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
             kpi_id TEXT NOT NULL,
             kind TEXT NOT NULL,
             title TEXT NOT NULL,
@@ -65,15 +69,25 @@ def _db() -> sqlite3.Connection:
             updated_at REAL NOT NULL
         );
         CREATE INDEX IF NOT EXISTS idx_kpi_flags_kpi ON kpi_flags(kpi_id, status, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_kpis_tenant ON kpis(tenant_id, created_at DESC);
     """)
+    for table in ("kpis", "kpi_values", "kpi_flags"):
+        try:
+            db.execute(f"SELECT tenant_id FROM {table} LIMIT 0")
+        except Exception:
+            try:
+                db.execute(f"ALTER TABLE {table} ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
+                db.commit()
+            except Exception:
+                pass
     return db
 
 
-def _fetch_history(db, kpi_id: str, limit: int = 30):
+def _fetch_history(db, kpi_id: str, tenant_id: str, limit: int = 30):
     rows = db.execute(
-        "SELECT id, value, source, notes, recorded_at FROM kpi_values WHERE kpi_id = ? "
+        "SELECT id, value, source, notes, recorded_at FROM kpi_values WHERE kpi_id = ? AND tenant_id = ? "
         "ORDER BY recorded_at DESC LIMIT ?",
-        (kpi_id, limit),
+        (kpi_id, tenant_id, limit),
     ).fetchall()
     return [dict(r) for r in rows]
 
@@ -83,17 +97,18 @@ def _fetch_history(db, kpi_id: str, limit: int = 30):
 # =============================================================================
 
 def kpi_list(status: str = "active", **kwargs) -> str:
+    tenant = require_tenant_context(kwargs=kwargs, consumer="kpi_list")
     db = _db()
     if status == "all":
-        rows = db.execute("SELECT * FROM kpis ORDER BY created_at DESC").fetchall()
+        rows = db.execute("SELECT * FROM kpis WHERE tenant_id = ? ORDER BY created_at DESC", (tenant.tenant_id,)).fetchall()
     else:
         rows = db.execute(
-            "SELECT * FROM kpis WHERE status = ? ORDER BY created_at DESC", (status,)
+            "SELECT * FROM kpis WHERE tenant_id = ? AND status = ? ORDER BY created_at DESC", (tenant.tenant_id, status)
         ).fetchall()
     kpis = []
     for r in rows:
         k = dict(r)
-        k["recent_values"] = _fetch_history(db, k["id"], limit=8)
+        k["recent_values"] = _fetch_history(db, k["id"], tenant.tenant_id, limit=8)
         kpis.append(k)
     return json.dumps({"count": len(kpis), "kpis": kpis})
 
@@ -118,15 +133,16 @@ KPI_LIST_SCHEMA = {
 # =============================================================================
 
 def kpi_get(kpi_id: str, history_limit: int = 30, **kwargs) -> str:
+    tenant = require_tenant_context(kwargs=kwargs, consumer="kpi_get")
     db = _db()
-    row = db.execute("SELECT * FROM kpis WHERE id = ?", (kpi_id,)).fetchone()
+    row = db.execute("SELECT * FROM kpis WHERE id = ? AND tenant_id = ?", (kpi_id, tenant.tenant_id)).fetchone()
     if not row:
         return json.dumps({"error": f"KPI {kpi_id} not found."})
     k = dict(row)
-    k["history"] = _fetch_history(db, kpi_id, limit=history_limit)
+    k["history"] = _fetch_history(db, kpi_id, tenant.tenant_id, limit=history_limit)
     open_flags = db.execute(
-        "SELECT * FROM kpi_flags WHERE kpi_id = ? AND status = 'open' ORDER BY created_at DESC",
-        (kpi_id,),
+        "SELECT * FROM kpi_flags WHERE tenant_id = ? AND kpi_id = ? AND status = 'open' ORDER BY created_at DESC",
+        (tenant.tenant_id, kpi_id),
     ).fetchall()
     k["open_flags"] = [dict(f) for f in open_flags]
     return json.dumps(k)
@@ -158,16 +174,17 @@ def kpi_set_measurement_plan(
     **kwargs,
 ) -> str:
     """Set or update the agent-authored measurement plan for a KPI."""
+    tenant = require_tenant_context(kwargs=kwargs, consumer="kpi_set_measurement_plan")
     db = _db()
-    row = db.execute("SELECT * FROM kpis WHERE id = ?", (kpi_id,)).fetchone()
+    row = db.execute("SELECT * FROM kpis WHERE id = ? AND tenant_id = ?", (kpi_id, tenant.tenant_id)).fetchone()
     if not row:
         return json.dumps({"error": f"KPI {kpi_id} not found."})
     if status not in ("configured", "failed", "pending"):
         status = "configured"
     now = time.time()
     db.execute(
-        "UPDATE kpis SET measurement_plan = ?, measurement_status = ?, measurement_error = ?, updated_at = ? WHERE id = ?",
-        (plan, status, error or None, now, kpi_id),
+        "UPDATE kpis SET measurement_plan = ?, measurement_status = ?, measurement_error = ?, updated_at = ? WHERE id = ? AND tenant_id = ?",
+        (plan, status, error or None, now, kpi_id, tenant.tenant_id),
     )
     db.commit()
     return json.dumps({"ok": True, "kpi_id": kpi_id, "measurement_status": status})
@@ -215,8 +232,9 @@ def kpi_record_value(
     **kwargs,
 ) -> str:
     """Record a new measurement for a KPI. Updates current/previous values."""
+    tenant = require_tenant_context(kwargs=kwargs, consumer="kpi_record_value")
     db = _db()
-    row = db.execute("SELECT * FROM kpis WHERE id = ?", (kpi_id,)).fetchone()
+    row = db.execute("SELECT * FROM kpis WHERE id = ? AND tenant_id = ?", (kpi_id, tenant.tenant_id)).fetchone()
     if not row:
         return json.dumps({"error": f"KPI {kpi_id} not found."})
 
@@ -228,13 +246,13 @@ def kpi_record_value(
     now = time.time()
     vid = uuid.uuid4().hex[:12]
     db.execute(
-        "INSERT INTO kpi_values (id, kpi_id, value, source, notes, recorded_at) VALUES (?, ?, ?, ?, ?, ?)",
-        (vid, kpi_id, value, source or None, notes or None, now),
+        "INSERT INTO kpi_values (id, tenant_id, kpi_id, value, source, notes, recorded_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (vid, tenant.tenant_id, kpi_id, value, source or None, notes or None, now),
     )
     db.execute(
         "UPDATE kpis SET previous_value = current_value, current_value = ?, last_measured_at = ?, "
-        "measurement_status = 'configured', measurement_error = NULL, updated_at = ? WHERE id = ?",
-        (value, now, now, kpi_id),
+        "measurement_status = 'configured', measurement_error = NULL, updated_at = ? WHERE id = ? AND tenant_id = ?",
+        (value, now, now, kpi_id, tenant.tenant_id),
     )
     db.commit()
 
@@ -292,8 +310,9 @@ def kpi_flag(
     if kind not in ("risk", "opportunity"):
         return json.dumps({"error": "kind must be 'risk' or 'opportunity'"})
 
+    tenant = require_tenant_context(kwargs=kwargs, consumer="kpi_flag")
     db = _db()
-    row = db.execute("SELECT id FROM kpis WHERE id = ?", (kpi_id,)).fetchone()
+    row = db.execute("SELECT id FROM kpis WHERE id = ? AND tenant_id = ?", (kpi_id, tenant.tenant_id)).fetchone()
     if not row:
         return json.dumps({"error": f"KPI {kpi_id} not found."})
 
@@ -307,10 +326,10 @@ def kpi_flag(
     flag_id = uuid.uuid4().hex[:12]
     now = time.time()
     db.execute(
-        "INSERT INTO kpi_flags (id, kpi_id, kind, title, description, references_json, "
+        "INSERT INTO kpi_flags (id, tenant_id, kpi_id, kind, title, description, references_json, "
         "brief_id, status, created_at, updated_at) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?, ?)",
-        (flag_id, kpi_id, kind, title, description or None,
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?)",
+        (flag_id, tenant.tenant_id, kpi_id, kind, title, description or None,
          json.dumps(refs), brief_id or None, now, now),
     )
     db.commit()
@@ -358,7 +377,7 @@ registry.register(
     name="kpi_list",
     toolset="pm-kpis",
     schema=KPI_LIST_SCHEMA,
-    handler=lambda args, **kw: kpi_list(status=args.get("status", "active")),
+    handler=lambda args, **kw: kpi_list(status=args.get("status", "active"), **kw),
 )
 
 registry.register(
@@ -368,6 +387,7 @@ registry.register(
     handler=lambda args, **kw: kpi_get(
         kpi_id=args.get("kpi_id", ""),
         history_limit=int(args.get("history_limit", 30)),
+        **kw,
     ),
 )
 
@@ -380,6 +400,7 @@ registry.register(
         plan=args.get("plan", ""),
         status=args.get("status", "configured"),
         error=args.get("error", ""),
+        **kw,
     ),
 )
 
@@ -392,6 +413,7 @@ registry.register(
         value=args.get("value"),
         source=args.get("source", ""),
         notes=args.get("notes", ""),
+        **kw,
     ),
 )
 
@@ -406,5 +428,6 @@ registry.register(
         description=args.get("description", ""),
         references=args.get("references", "[]"),
         brief_id=args.get("brief_id", ""),
+        **kw,
     ),
 )

--- a/tools/pm_workspace_tools.py
+++ b/tools/pm_workspace_tools.py
@@ -11,17 +11,14 @@ import os
 import time
 from typing import Optional
 
+from backend.tenant_context import require_tenant_context
 from workspace_context import WorkspaceContext, load_workspace_context
 from tools.registry import registry
 
 
-def _get_ctx() -> WorkspaceContext:
-    ws_id = (
-        os.environ.get("KAI_WORKSPACE_ID")
-        or os.environ.get("HERMES_WORKSPACE_ID")
-        or "default"
-    )
-    return load_workspace_context(workspace_id=ws_id)
+def _get_ctx(**kwargs) -> WorkspaceContext:
+    tenant = require_tenant_context(kwargs=kwargs, consumer="pm_workspace_tools")
+    return load_workspace_context(workspace_id=tenant.tenant_id)
 
 
 # =============================================================================
@@ -30,7 +27,7 @@ def _get_ctx() -> WorkspaceContext:
 
 def workspace_get_blueprint(**kwargs) -> str:
     """Get the current workspace blueprint."""
-    ctx = _get_ctx()
+    ctx = _get_ctx(**kwargs)
     bp = ctx.get_blueprint()
     if not bp:
         return json.dumps({"message": "No blueprint yet. Run onboarding to create one."})
@@ -54,7 +51,7 @@ WORKSPACE_GET_BLUEPRINT_SCHEMA = {
 
 def workspace_update_blueprint(summary: str, data: str, **kwargs) -> str:
     """Update the workspace blueprint."""
-    ctx = _get_ctx()
+    ctx = _get_ctx(**kwargs)
     try:
         parsed_data = json.loads(data) if isinstance(data, str) else data
     except json.JSONDecodeError:
@@ -90,7 +87,7 @@ WORKSPACE_UPDATE_BLUEPRINT_SCHEMA = {
 
 def workspace_get_learnings(category: str = "", limit: int = 20, **kwargs) -> str:
     """Get workspace learnings, optionally filtered by category."""
-    ctx = _get_ctx()
+    ctx = _get_ctx(**kwargs)
     learnings = ctx.get_learnings(limit=limit)
     if category:
         learnings = [l for l in learnings if l["category"] == category]
@@ -124,7 +121,7 @@ WORKSPACE_GET_LEARNINGS_SCHEMA = {
 
 def workspace_add_learning(category: str, content: str, **kwargs) -> str:
     """Add a learning to the workspace."""
-    ctx = _get_ctx()
+    ctx = _get_ctx(**kwargs)
     ctx.add_learning(category, content)
     return json.dumps({"success": True, "message": f"Learning added [{category}]."})
 
@@ -155,7 +152,7 @@ WORKSPACE_ADD_LEARNING_SCHEMA = {
 
 def workspace_set_onboarding_status(status: str, phase: str = "", **kwargs) -> str:
     """Update workspace onboarding status."""
-    ctx = _get_ctx()
+    ctx = _get_ctx(**kwargs)
     ctx.set_onboarding_status(status, phase or None)
     return json.dumps({"success": True, "status": status, "phase": phase})
 
@@ -189,7 +186,7 @@ registry.register(
     name="workspace_get_blueprint",
     toolset="pm-workspace",
     schema=WORKSPACE_GET_BLUEPRINT_SCHEMA,
-    handler=lambda args, **kw: workspace_get_blueprint(),
+    handler=lambda args, **kw: workspace_get_blueprint(**kw),
 )
 
 registry.register(
@@ -198,7 +195,8 @@ registry.register(
     schema=WORKSPACE_UPDATE_BLUEPRINT_SCHEMA,
     handler=lambda args, **kw: workspace_update_blueprint(
         summary=args.get("summary", ""),
-        data=args.get("data", "{}")),
+        data=args.get("data", "{}"),
+        **kw),
 )
 
 registry.register(
@@ -207,7 +205,8 @@ registry.register(
     schema=WORKSPACE_GET_LEARNINGS_SCHEMA,
     handler=lambda args, **kw: workspace_get_learnings(
         category=args.get("category", ""),
-        limit=int(args.get("limit", 20))),
+        limit=int(args.get("limit", 20)),
+        **kw),
 )
 
 registry.register(
@@ -216,7 +215,8 @@ registry.register(
     schema=WORKSPACE_ADD_LEARNING_SCHEMA,
     handler=lambda args, **kw: workspace_add_learning(
         category=args.get("category", ""),
-        content=args.get("content", "")),
+        content=args.get("content", ""),
+        **kw),
 )
 
 registry.register(
@@ -225,5 +225,6 @@ registry.register(
     schema=WORKSPACE_SET_ONBOARDING_STATUS_SCHEMA,
     handler=lambda args, **kw: workspace_set_onboarding_status(
         status=args.get("status", ""),
-        phase=args.get("phase", "")),
+        phase=args.get("phase", ""),
+        **kw),
 )


### PR DESCRIPTION
### Motivation

- Enforce multi-tenant access control for tenant-scoped API paths by decoding Supabase JWTs and resolving membership via `tenant_memberships` so requests are always scoped to a tenant. 
- Propagate resolved tenant identity into the request/tool execution context so PM tools operate on the correct `tenant_id` instead of assuming a global workspace. 
- Provide a gateway hook to map messaging source identifiers to tenant IDs to support platform-initiated requests (Slack/Telegram). 

### Description

- Added tenant identity libraries: `backend/tenant_auth.py` (Supabase JWT extraction, membership resolution, `build_tenant_context`, `get_current_tenant`) and `backend/tenant_context.py` (ContextVar-based `TenantContext`, `require_tenant_context` helper). 
- Wired a FastAPI middleware in `server.py` that runs on tenant-scoped paths, decodes/resolves the Supabase JWT, attaches `request.state.tenant_context`, sets `KAI_*`/`HERMES_*` env vars for downstream tools, and exposes `get_current_tenant` as a dependency (clear 401/403/500 semantics). 
- Propagated tenant context into PM tools and their DB paths by requiring tenant context and scoping queries/writes by `tenant_id` in: `tools/pm_brief_tools.py`, `tools/pm_goal_tools.py`, `tools/pm_kpi_tools.py`, and `tools/pm_workspace_tools.py`; added lightweight migrations/indexes to include `tenant_id` columns in local SQLite tables. 
- Added gateway mapping interface `gateway/tenant_resolver.py` and integrated an env-backed resolver (`TENANT_SOURCE_MAP`) into `gateway/run.py` to set `KAI_TENANT_ID`/`HERMES_TENANT_ID` for session dispatch. 
- Documentation: updated `docs/supabase-setup.md` to describe middleware behavior, failure semantics, and the gateway mapping stub. 
- Tests: added `tests/test_tenant_auth_middleware.py` covering 401/403 resolution and tenant isolation; registry handlers updated to forward runtime kwargs (`**kw`) into tool handlers so the context is forwarded.

### Testing

- Performed syntax checks with `python -m py_compile server.py backend/tenant_auth.py backend/tenant_context.py gateway/tenant_resolver.py tools/pm_workspace_tools.py tools/pm_goal_tools.py tools/pm_kpi_tools.py tools/pm_brief_tools.py tests/test_tenant_auth_middleware.py`, which succeeded. 
- Ran unit tests `pytest -q -o addopts='' tests/test_tenant_auth_middleware.py tests/tools/test_pm_brief_tools.py` and the suite passed (`6 passed`). 

Closes #27

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb771434d483219a28c37d7334c045)